### PR TITLE
Added a Partner Balance Check when the Network Question Run Batch is being initialized.

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,6 +183,7 @@ func main() {
 	scheduledProcessor := workflows.NewScheduledProcessor(orgService, repoManager)
 	networkProcessor := workflows.NewNetworkProcessor( // ** THIS IS THE NETWORK QUESTION RUNNER **
 		questionRunnerService,
+		usageService,
 		repoManager,
 		cfg,
 	)

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -51,6 +51,8 @@ type RepositoryManager struct {
 	NetworkModelRepo interfaces.NetworkModelRepository
 	// Wholesale pricing config repository
 	WholesalePricingConfigRepo interfaces.WholesalePricingConfigRepository
+	// Network repository
+	NetworkRepo interfaces.NetworkRepository
 }
 
 // NewRepositoryManager creates a new repository manager with all repositories
@@ -90,6 +92,8 @@ func NewRepositoryManager(db *database.Client) *RepositoryManager {
 		NetworkModelRepo: postgresql.NewNetworkModelRepo(db),
 		// Wholesale pricing config repository
 		WholesalePricingConfigRepo: postgresql.NewWholesalePricingConfigRepo(db),
+		// Network respository
+		NetworkRepo: postgresql.NewNetworkRepo(db),
 	}
 }
 


### PR DESCRIPTION
## Added a Partner Balance Check when the Network Question Run Batch is being initialized.

Currently the Balance Check for Network questions is after the question runs are already complete and before the network org evals are done. This PR adds a Partner Balance check before the question runs are even started. 

It takes the total number of question runs for the network and multiplies by the number of orgs in the network to determine how many evals will need to run. 

This PR also gives the eval pipeline access to the NetworkRepo from `senso-api`